### PR TITLE
example code fix, capital letters didn't worked

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ while (cursor.hasNext()) {
 
 Sort by key
 ```
-Cursor<Point> cursor = repo.getQuery().sort("X", PropertySort.Direction.DESCENDING).execute();
+Cursor<Point> cursor = repo.getQuery().sort("x", PropertySort.Direction.DESCENDING).execute();
 while (cursor.hasNext()) {
 	Point p = cursor.next();
 	...
@@ -114,7 +114,7 @@ while (cursor.hasNext()) {
 
 Windowing
 ```
-Cursor<Point> cursor = repo.getQuery().limit(11,10).sort("X", PropertySort.Direction.DESCENDING).execute();
+Cursor<Point> cursor = repo.getQuery().limit(11,10).sort("x", PropertySort.Direction.DESCENDING).execute();
 while (cursor.hasNext()) {
 	Point p = cursor.next();
 	...


### PR DESCRIPTION
Beim Nachvollziehen des Beispielcodes habe ich gemerkt, dass die Sortierung nicht funktioniert hat. Offenbar ist die Kleinschreibung wichtig (zumindest auf meinem Windowssystem).
